### PR TITLE
Fixed Ingress definition in Frontend.yaml

### DIFF
--- a/frontend.yaml
+++ b/frontend.yaml
@@ -48,7 +48,7 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-   annotations:
+  annotations:
     cert-manager.io/issuer: "letsencrypt"
     external-dns.alpha.kubernetes.io/hostname: $host
     external-dns.alpha.kubernetes.io/target: aks.srinipadala.xyz


### PR DESCRIPTION
There was an additional space in the annotations field for the ingress that was causing an error. Fixed it