### PR TITLE
Flagger and Linkerd AAD Auth

### DIFF
--- a/azuread-linkerd-dashboard.yml
+++ b/azuread-linkerd-dashboard.yml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy-azuread
+  namespace: linkerd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: oauth2-proxy
+    spec:
+      containers:
+      - args:
+        - --provider=azure
+        - --email-domain=*
+        - --upstream=file:///dev/null
+        - --http-address=0.0.0.0:4180
+        # Register a new application
+        # https://github.com/settings/applications/new
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          value: ad586b11-baf8-4aff-8f70-20b5755c8209
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          value: i50p8=y?NB_X]ld3r4ouR6nr_vQ5C[d=
+        # docker run -ti --rm python:3-alpine python -c 'import secrets,base64; print(base64.b64encode(base64.b64encode(secrets.token_bytes(16))));'
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          value: TVl3Nk1CQ1FKVm1VbE90eEQrSEJBZz09
+        image: quay.io/pusher/oauth2_proxy:latest
+        imagePullPolicy: Always
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy-azuread
+  namespace: linkerd
+spec:
+  ports:
+  - name: http
+    port: 4180
+    protocol: TCP
+    targetPort: 4180
+  selector:
+    k8s-app: oauth2-proxy
+
+---
+
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    external-dns.alpha.kubernetes.io/hostname: $host
+    external-dns.alpha.kubernetes.io/target: aks.srinipadala.xyz
+    nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "16"    
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Origin "";
+      proxy_hide_header l5d-remote-ip;
+      proxy_hide_header l5d-server-id;
+  name: linkerd-oauth2-azuread
+  namespace: linkerd
+spec:
+  rules:
+  - host: linkerd-dashboard.aks.srinipadala.xyz
+    http:
+      paths:
+      - backend:
+          serviceName: linkerd-web
+          servicePort: 8084
+        path: /
+
+---
+
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: oauth2-proxy-azuread
+  namespace: linkerd
+  annotations:
+    cert-manager.io/issuer: "letsencrypt"
+spec:
+  rules:
+  - host: linkerd-dashboard.aks.srinipadala.xyz
+    http:
+      paths:
+      - backend:
+          serviceName: oauth2-proxy-azuread
+          servicePort: 4180
+        path: /oauth2
+  tls:
+  - hosts:
+    - linkerd-dashboard.aks.srinipadala.xyz
+    secretName: linkerd-aks-dashboard-cert

--- a/conexp-flagger-frontend.yaml
+++ b/conexp-flagger-frontend.yaml
@@ -1,0 +1,62 @@
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: frontend
+spec:
+  # deployment reference
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+     # HPA reference (optional)
+  autoscalerRef:
+    apiVersion: autoscaling/v2beta1
+    kind: HorizontalPodAutoscaler
+    name: frontend
+  # the maximum time in seconds for the canary deployment
+  # to make progress before it is rollback (default 600s)
+  progressDeadlineSeconds: 60
+  service:
+    # ClusterIP port number
+    port: 80
+    # container port number or name (optional)
+    targetPort: 80
+  analysis:
+    # schedule interval (default 60s)
+    interval: 30s
+    # max number of failed metric checks before rollback
+    threshold: 10
+    # max traffic percentage routed to canary
+    # percentage (0-100)
+    maxWeight: 100
+    # canary increment step
+    # percentage (0-100)
+    stepWeight: 5
+    # Linkerd Prometheus checks
+    metrics:
+    - name: request-success-rate
+      # minimum req success rate (non 5xx responses)
+      # percentage (0-100)
+      thresholdRange:
+        min: 99
+      interval: 1m
+    - name: request-duration
+      # maximum req duration P99
+      # milliseconds
+      thresholdRange:
+        max: 500
+      interval: 30s
+    # testing (optional)
+    webhooks:
+      - name: acceptance-test
+        type: pre-rollout
+        url: http://flagger-loadtester.conexp-mvp/
+        timeout: 30s
+        metadata:
+          type: bash
+          cmd: "curl -s http://frontend"
+      - name: frontend-load-test
+        type: rollout
+        url: http://flagger-loadtester.conexp-mvp/
+        metadata:
+          cmd: "hey -z 2m -q 10 -c 2 http://frontend/Expenses"

--- a/frontend.yaml
+++ b/frontend.yaml
@@ -1,74 +1,96 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: frontend-deployment
+  name: frontend
   labels:
-    app: frontend-deployment
+    app: frontend
 spec:
-  replicas: 1
+  minReadySeconds: 5
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
-      app: frontend-deployment
+      app: frontend
   template:
     metadata:
       labels:
-        app: frontend-deployment
+        app: frontend
     spec:
       containers:
-      - name: frontend-deployment
+      - name: frontend
         image: __IMAGE__
         ports:
-        - containerPort: 80  
+        - name: http
+          containerPort: 80
+          protocol: TCP
         imagePullPolicy: Always
         env:
         - name: ConnectionStrings__DBConnectionString
           value: "__WEBDBCONSTR__"
         - name: ConfigValues__CostCenterAPIUrl
           value: "__APIURL__"
+        livenessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /Expenses
+            port: http
       imagePullSecrets:
       - name: regcred
       nodeSelector: 
         "beta.kubernetes.io/os": linux
 ---
-apiVersion: v1
-kind: Service
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
 metadata:
-  name: frontend-deployment
-  labels:
-    app: frontend-deployment
+  name: frontend
 spec:
-  selector:
-    app: frontend-deployment
-  ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 80
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      # scale up if usage is above
+      # 99% of the requested CPU (100m)
+      targetAverageUtilization: 99
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     external-dns.alpha.kubernetes.io/hostname: $host
     external-dns.alpha.kubernetes.io/target: aks.srinipadala.xyz
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local;
+      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:80;
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
-  name: frontend-deployment
+  name: frontend
   labels:
-    app: frontend-deployment
+    app: frontend
 spec:
   rules:
-  - host: frontend-deployment.aks.srinipadala.xyz
+  - host: contoso-expenses.aks.srinipadala.xyz
     http:
       paths:
       - backend:
-          serviceName: frontend-deployment
+          serviceName: frontend
           servicePort: 80
   tls:
   - hosts:
-    - frontend-deployment.aks.srinipadala.xyz
-    secretName: frontend-deployment-secret
+    - contoso-expenses.aks.srinipadala.xyz
+    secretName: contoso-expenses-ingress-secret


### PR DESCRIPTION
This code makes the following changes:

1. Deletes the Frontend Service Object from Frontend.yaml
2. Adds a Horizontal Pod Autoscaler object to Frontend.yaml
3. Adds Liveness and Readiness probes to the Frontend container
4. Adds the YAML file for integrating the Linkerd dashaboard with Azure AD authentication
5. Configures the Flagger Canary for Linkerd provider to watch for changes in Frontend Deployment