### PR TITLE
Flagger Canary for Backend Service

### DIFF
--- a/backend.yaml
+++ b/backend.yaml
@@ -1,44 +1,65 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backend-deployment
+  name: backend
   labels:
-    app: backend-deployment
+    app: backend
 spec:
-  replicas: 1
+  minReadySeconds: 5
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
-      app: backend-deployment
+      app: backend
   template:
     metadata:
       labels:
-        app: backend-deployment
+        app: backend
     spec:
       containers:
-      - name: backend-deployment
+      - name: backend
         image: __IMAGE__
         ports:
-        - containerPort: 80
+        - name: http
+          containerPort: 80
+          protocol: TCP
         imagePullPolicy: Always
         env:
         - name: ConnectionStrings__DBConnectionString
           value: "__APIDBCONSTR__"
+      livenessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /api/costcenter
+            port: http
       imagePullSecrets:
       - name: regcred
       nodeSelector: 
         "beta.kubernetes.io/os": linux
 ---
-apiVersion: v1
-kind: Service
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
 metadata:
-  name: backend-deployment
-  labels:
-    app: backend-deployment
+  name: backend
 spec:
-  selector:
-    app: backend-deployment
-  ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 80
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      # scale up if usage is above
+      # 99% of the requested CPU (100m)
+      targetAverageUtilization: 99

--- a/conexp-flagger-backend.yaml
+++ b/conexp-flagger-backend.yaml
@@ -1,0 +1,62 @@
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: backend
+spec:
+  # deployment reference
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+     # HPA reference (optional)
+  autoscalerRef:
+    apiVersion: autoscaling/v2beta1
+    kind: HorizontalPodAutoscaler
+    name: backend
+  # the maximum time in seconds for the canary deployment
+  # to make progress before it is rollback (default 600s)
+  progressDeadlineSeconds: 60
+  service:
+    # ClusterIP port number
+    port: 80
+    # container port number or name (optional)
+    targetPort: 80
+  analysis:
+    # schedule interval (default 60s)
+    interval: 30s
+    # max number of failed metric checks before rollback
+    threshold: 10
+    # max traffic percentage routed to canary
+    # percentage (0-100)
+    maxWeight: 100
+    # canary increment step
+    # percentage (0-100)
+    stepWeight: 5
+    # Linkerd Prometheus checks
+    metrics:
+    - name: request-success-rate
+      # minimum req success rate (non 5xx responses)
+      # percentage (0-100)
+      thresholdRange:
+        min: 99
+      interval: 1m
+    - name: request-duration
+      # maximum req duration P99
+      # milliseconds
+      thresholdRange:
+        max: 500
+      interval: 30s
+    # testing (optional)
+    webhooks:
+      - name: backend-acceptance-test
+        type: pre-rollout
+        url: http://flagger-loadtester.conexp-mvp/
+        timeout: 30s
+        metadata:
+          type: bash
+          cmd: "curl -s http://backend/api/costcenter"
+      - name: backend-load-test
+        type: rollout
+        url: http://flagger-loadtester.conexp-mvp/
+        metadata:
+          cmd: "hey -z 2m -q 10 -c 2 http://backend/api/costcenter"


### PR DESCRIPTION
This commit has the following

1. Added a Flagger Canary for the backend service
2. Updated backend.yaml file with the following:
  a. Removed the service object since now Flagger will create
  b. Updated all labels and match selectors to be the deployment name (backend) in order to work with Flagger
  c. Created an Horizontal Pod Autoscaler object for the backend deployment